### PR TITLE
Use latest jasmine-expect-jsx

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,6 @@
   "homepage": "https://github.com/smacker/karma-jasmine-expect-jsx#readme",
   "dependencies": {
     "chalk": "1.1.1",
-    "jasmine-expect-jsx": "^1.1.1"
+    "jasmine-expect-jsx": "^3.0.0"
   }
 }


### PR DESCRIPTION
Thank you for updating jasmine-expect-jsx. I was hoping this could be updated as well to use the latest version.